### PR TITLE
Fix typos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,7 @@ typings/
 
 # End of https://www.gitignore.io/api/macos,visualstudiocode,node
 
-# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+# Custom rules (everything added below won't be overridden by 'Generate .gitignore File' if you use 'Update' option)
 
 # Built files
 dist/

--- a/src/_staart/helpers/authorization.ts
+++ b/src/_staart/helpers/authorization.ts
@@ -208,7 +208,7 @@ export const can = async (
   /**
    * Now, `user` is of type "users", "ApiKeyResponse", or "AccessTokenResponse"
    * and `requestFromType` will tell us what type it is
-   * We fidn what the correct target is
+   * We find what the correct target is
    */
   if (typeof target === "string") {
     if (targetType === "membership") {


### PR DESCRIPTION
```
.gitignore:132:48: "overriden" is a misspelling of "overridden"
src/_staart/helpers/authorization.ts:211:8: "fidn" is a misspelling of "find"
```